### PR TITLE
Secure editor mode with PIN and accessibility updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <!-- SortableJS -->
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <style>
         /* Настройка шрифта и скроллинга */
         body {
@@ -56,9 +58,126 @@
         .animate-fade-in-down {
             animation: fade-in-down 0.5s ease-out forwards;
         }
+        body:not(.editor-mode) .editor-only,
+        body:not(.editor-mode) .js-drag {
+            display: none !important;
+        }
+
+        body.editor-mode .js-drag {
+            cursor: grab;
+        }
+
+        body.editor-mode .js-drag:active {
+            cursor: grabbing;
+        }
+
+        #editor-panel {
+            display: none;
+        }
+
+        #editor-panel button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        body.editor-mode #editor-panel {
+            display: flex;
+        }
+
+        body.editor-mode .js-editable {
+            outline: 1px dashed rgba(37, 99, 235, 0.35);
+            outline-offset: 2px;
+        }
+
+        body.editor-mode .js-editable:focus-visible {
+            outline: 2px solid #2563eb;
+            outline-offset: 2px;
+        }
+
+        body.editor-mode [data-group-id] {
+            outline: 1px dashed rgba(107, 114, 128, 0.35);
+            outline-offset: 4px;
+        }
+
+        body.editor-mode [data-item-id] {
+            outline: 1px dashed rgba(148, 163, 184, 0.4);
+            outline-offset: 2px;
+        }
+
+        #editor-toggle:focus-visible,
+        #editor-panel button:focus-visible {
+            outline: 3px solid rgba(37, 99, 235, 0.6);
+            outline-offset: 2px;
+        }
+
+        body:not(.editor-mode) .js-editable:focus {
+            outline: none;
+        }
     </style>
 </head>
 <body>
+
+    <button
+        id="editor-toggle"
+        type="button"
+        class="fixed top-4 right-4 z-50 px-4 py-2 rounded-md bg-gray-900 text-white shadow-lg"
+        aria-controls="editor-panel"
+        aria-label="Переключить режим редактирования"
+        aria-pressed="false"
+        style="display: none;"
+    >
+        Редактировать
+    </button>
+
+    <div
+        id="editor-panel"
+        class="fixed top-20 right-4 z-40 flex w-56 flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 shadow-xl"
+        role="region"
+        aria-hidden="true"
+        aria-label="Панель редактора"
+        style="display: none;"
+    >
+        <div class="grid grid-cols-2 gap-2">
+            <button
+                type="button"
+                data-editor-action="undo"
+                class="rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-300"
+                aria-label="Отменить последнее изменение"
+                disabled
+            >
+                Отменить
+            </button>
+            <button
+                type="button"
+                data-editor-action="redo"
+                class="rounded-lg bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-300"
+                aria-label="Повторить отменённое изменение"
+                disabled
+            >
+                Повторить
+            </button>
+        </div>
+        <button
+            type="button"
+            data-editor-action="export"
+            class="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700"
+            aria-label="Экспортировать состояние сайта в JSON"
+        >
+            Экспорт JSON
+        </button>
+        <button
+            type="button"
+            data-editor-action="import"
+            class="w-full rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-600"
+            aria-label="Импортировать состояние сайта из JSON"
+        >
+            Импорт JSON
+        </button>
+        <input id="editor-import-input" type="file" accept="application/json" class="hidden" />
+        <p class="text-xs leading-snug text-gray-500">
+            Импорт заменит текущее состояние. Перед загрузкой сохраните резервную копию.
+        </p>
+    </div>
 
     <div id="app" class="min-h-screen">
         <!-- Содержимое будет сгенерировано JS -->


### PR DESCRIPTION
## Summary
- require a locally stored PIN when ?edit=1 is present before activating editor mode and reuse the same authorization flow in both entry points
- add subtle outlines, cursor changes, and ARIA labelling so editor controls are hidden in normal mode but focusable and descriptive while editing
- hide drag handles outside the editor, keep sortable refreshes tied to the mode flag, and ensure the panel updates aria-hidden state during toggles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df636db9888333814c9ea3bd302f5e