### PR TITLE
Fix persistent editor mode toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const CONFIG = {
         editorImport: '[data-editor-action="import"]',
         editorHealthIndicator: '[data-editor-health-indicator]',
         editorHealthText: '[data-editor-health-text]',
-        editable: '.js-editable',
+        editable: '.js-editable, [data-editable]',
         dragHandle: '.js-drag',
         groupsContainer: '[data-groups-container="catalog"]',
     },
@@ -83,6 +83,18 @@ function isTruthyEditValue(rawValue) {
 function getEditFlag() {
     if (typeof window === 'undefined') {
         return false;
+    }
+
+    if (window.EditorSession && typeof window.EditorSession.isEditModeRequested === 'function') {
+        try {
+            const requested = window.EditorSession.isEditModeRequested();
+            if (typeof requested === 'boolean') {
+                return requested;
+            }
+            return Boolean(requested);
+        } catch (error) {
+            console.warn('[EDITOR:FLAG]', 'session-read', error);
+        }
     }
 
     try {
@@ -565,7 +577,7 @@ const Editor = (() => {
 
     const updateButtonState = () => {
         if (!state.button) return;
-        const label = state.isActive ? 'Завершить редактирование' : 'Редактировать';
+        const label = state.isActive ? 'Выключить редактирование' : 'Редактировать';
         state.button.textContent = label;
         state.button.setAttribute('aria-pressed', String(state.isActive));
         state.button.setAttribute('aria-label', state.isActive ? 'Выключить режим редактирования' : 'Включить режим редактирования');

--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,216 @@
+(function () {
+    const EDIT_PARAM = 'edit';
+    const SESSION_STORAGE_KEY = 'editor:mode:requested';
+    const BUTTON_ID = 'editor-toggle';
+    const PANEL_ID = 'editor-panel';
+    const BUTTON_CLASSES = 'fixed top-4 right-4 z-50 inline-flex min-h-[44px] min-w-[44px] items-center justify-center gap-2 rounded-md bg-gray-900 px-4 py-2 text-white shadow-lg';
+    const BUTTON_DEFAULT_LABEL = 'Редактировать';
+
+    const state = {
+        requested: false,
+        button: null,
+        initialized: false,
+    };
+
+    const safeWindow = typeof window !== 'undefined' ? window : null;
+
+    function isTruthyEditValue(rawValue) {
+        if (rawValue === undefined || rawValue === null) {
+            return true;
+        }
+        const normalized = String(rawValue).trim().toLowerCase();
+        if (!normalized) return true;
+        return normalized === '1'
+            || normalized === 'true'
+            || normalized === 'yes'
+            || normalized === 'on';
+    }
+
+    function readSessionFlag() {
+        if (!safeWindow || !safeWindow.sessionStorage) {
+            return false;
+        }
+        try {
+            return safeWindow.sessionStorage.getItem(SESSION_STORAGE_KEY) === '1';
+        } catch (error) {
+            console.warn('[editor:session] read failed', error);
+            return false;
+        }
+    }
+
+    function writeSessionFlag(value) {
+        if (!safeWindow || !safeWindow.sessionStorage) {
+            return;
+        }
+        try {
+            if (value) {
+                safeWindow.sessionStorage.setItem(SESSION_STORAGE_KEY, '1');
+            } else {
+                safeWindow.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+            }
+        } catch (error) {
+            console.warn('[editor:session] write failed', error);
+        }
+    }
+
+    function detectEditFromSearch() {
+        if (!safeWindow) {
+            return { found: false, value: false };
+        }
+        try {
+            const params = new URLSearchParams(safeWindow.location.search || '');
+            if (!params.has(EDIT_PARAM)) {
+                return { found: false, value: false };
+            }
+            const raw = params.get(EDIT_PARAM);
+            return { found: true, value: isTruthyEditValue(raw) };
+        } catch (error) {
+            console.warn('[editor:detect] search parse failed', error);
+            return { found: false, value: false };
+        }
+    }
+
+    function detectEditFromHash() {
+        if (!safeWindow) {
+            return { found: false, value: false };
+        }
+        const hash = safeWindow.location.hash || '';
+        if (!hash) {
+            return { found: false, value: false };
+        }
+        const match = hash.match(/[?&]edit(?:=([^&#]*))?/i);
+        if (!match) {
+            return { found: false, value: false };
+        }
+        try {
+            const raw = match[1] ? decodeURIComponent(match[1]) : '';
+            return { found: true, value: isTruthyEditValue(raw) };
+        } catch (error) {
+            console.warn('[editor:detect] hash parse failed', error);
+            return { found: true, value: true };
+        }
+    }
+
+    function detectEditFromLocation() {
+        const fromSearch = detectEditFromSearch();
+        if (fromSearch.found) {
+            return fromSearch;
+        }
+        const fromHash = detectEditFromHash();
+        if (fromHash.found) {
+            return fromHash;
+        }
+        return { found: false, value: false };
+    }
+
+    function ensureButtonMounted() {
+        if (!safeWindow || !safeWindow.document || !safeWindow.document.body) {
+            return;
+        }
+        let button = safeWindow.document.getElementById(BUTTON_ID);
+        if (!button) {
+            button = safeWindow.document.createElement('button');
+            button.id = BUTTON_ID;
+            button.type = 'button';
+            button.className = BUTTON_CLASSES;
+            button.hidden = true;
+            button.setAttribute('aria-controls', PANEL_ID);
+            button.setAttribute('aria-label', 'Переключить режим редактирования');
+            button.setAttribute('aria-pressed', 'false');
+            button.textContent = BUTTON_DEFAULT_LABEL;
+            button.dataset.editorFloating = 'true';
+            safeWindow.document.body.appendChild(button);
+        } else if (button.parentElement !== safeWindow.document.body) {
+            safeWindow.document.body.appendChild(button);
+        }
+        state.button = button;
+    }
+
+    function notifyConsumers() {
+        if (safeWindow && safeWindow.editorMode && typeof safeWindow.editorMode.refresh === 'function') {
+            safeWindow.editorMode.refresh();
+        }
+        if (safeWindow) {
+            const event = new CustomEvent('editor:request-changed', {
+                detail: { requested: state.requested },
+            });
+            safeWindow.dispatchEvent(event);
+        }
+    }
+
+    function updateButtonVisibility() {
+        if (!state.button) return;
+        state.button.hidden = !state.requested;
+        state.button.setAttribute('aria-hidden', state.requested ? 'false' : 'true');
+        state.button.dataset.editorRequested = state.requested ? 'true' : 'false';
+        if (!state.button.textContent || !state.button.textContent.trim()) {
+            state.button.textContent = BUTTON_DEFAULT_LABEL;
+        }
+    }
+
+    function setRequested(value, { persist = true, notify = true } = {}) {
+        const normalized = Boolean(value);
+        if (persist) {
+            writeSessionFlag(normalized);
+        }
+        const changed = state.requested !== normalized;
+        state.requested = normalized;
+        updateButtonVisibility();
+        if (changed && notify) {
+            notifyConsumers();
+        }
+        return state.requested;
+    }
+
+    function syncFromLocation({ reason = 'navigation' } = {}) {
+        const detection = detectEditFromLocation();
+        if (detection.found) {
+            return setRequested(detection.value, { persist: true, notify: true });
+        }
+        if (reason === 'init') {
+            writeSessionFlag(false);
+            return setRequested(false, { persist: false, notify: true });
+        }
+        const stored = readSessionFlag();
+        return setRequested(stored, { persist: false, notify: true });
+    }
+
+    function handleLocationChange(event) {
+        syncFromLocation({ reason: event?.type || 'navigation' });
+    }
+
+    function init() {
+        if (state.initialized) return;
+        ensureButtonMounted();
+        syncFromLocation({ reason: 'init' });
+        updateButtonVisibility();
+        if (safeWindow) {
+            safeWindow.addEventListener('hashchange', handleLocationChange);
+            safeWindow.addEventListener('popstate', handleLocationChange);
+        }
+        state.initialized = true;
+    }
+
+    const api = {
+        isEditModeRequested() {
+            return Boolean(state.requested);
+        },
+        setEditModeRequested(value, options) {
+            return setRequested(value, options);
+        },
+        syncFromLocation,
+        readSessionFlag,
+    };
+
+    if (safeWindow) {
+        safeWindow.EditorSession = api;
+    }
+
+    if (safeWindow && safeWindow.document) {
+        if (safeWindow.document.readyState === 'loading') {
+            safeWindow.document.addEventListener('DOMContentLoaded', init, { once: true });
+        } else {
+            init();
+        }
+    }
+})();

--- a/index.html
+++ b/index.html
@@ -84,18 +84,21 @@
             display: flex;
         }
 
-        body.editor-mode .js-editable {
+        body.editor-mode .js-editable,
+        body.editor-mode [data-editable] {
             outline: 1px dashed rgba(37, 99, 235, 0.35);
             outline-offset: 2px;
             cursor: text;
             transition: background-color 0.2s ease-in-out;
         }
 
-        body.editor-mode .js-editable:hover {
+        body.editor-mode .js-editable:hover,
+        body.editor-mode [data-editable]:hover {
             background-color: rgba(37, 99, 235, 0.04);
         }
 
-        body.editor-mode .js-editable:focus-visible {
+        body.editor-mode .js-editable:focus-visible,
+        body.editor-mode [data-editable]:focus-visible {
             outline: 2px solid #2563eb;
             outline-offset: 2px;
         }
@@ -116,7 +119,8 @@
             outline-offset: 2px;
         }
 
-        body:not(.editor-mode) .js-editable:focus {
+        body:not(.editor-mode) .js-editable:focus,
+        body:not(.editor-mode) [data-editable]:focus {
             outline: none;
         }
     </style>
@@ -197,6 +201,7 @@
         <!-- Содержимое будет сгенерировано JS -->
     </div>
 
+    <script defer src="editor.js"></script>
     <!-- Подключаем файл с каталогом -->
     <script src="catalog.js"></script>
     <!-- Загрузка единого файла логики -->


### PR DESCRIPTION
## Summary
- add a dedicated editor session helper that mounts the floating toggle, watches URL/search parameters, and persists the edit request in session storage
- teach the main app logic to consume the shared edit flag, support [data-editable] targets, and show the updated Russian labels
- extend the base markup/styles to include the new script and apply editor styling to data-editable elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb32828208333a813d6fcf9a462cd